### PR TITLE
Fix Vercel configuration conflict for Node deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,14 @@
-  {
+{
   "version": 2,
-  "builds": [
-    { "src": "index.js", "use": "@vercel/node" }
-  ],
+  "functions": {
+    "index.js": {
+      "runtime": "nodejs20.x"
+    }
+  },
   "routes": [
-    { "src": "/(.*)", "dest": "index.js" }
+    {
+      "src": "/(.*)",
+      "dest": "/index.js"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the legacy Vercel builds configuration with a functions-based setup targeting the Node.js 20 runtime
- ensure all routes are rewritten to the Express entrypoint and ignore local node_modules in git

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e50f63a6c48326b205c1368641a933