### PR TITLE
Fix Google OAuth redirect configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,8 @@ function ensureGoogleCredentials() {
   return {
     clientId,
     clientSecret,
-    redirectUri: process.env.REDIRECT_URI || DEFAULT_CALLBACK
+    redirectUri:
+      process.env.GOOGLE_REDIRECT_URI || process.env.REDIRECT_URI || DEFAULT_CALLBACK
   };
 }
 
@@ -223,6 +224,9 @@ function createApp() {
       googleParams.set("code_challenge", codeChallenge);
       googleParams.set("code_challenge_method", codeChallengeMethod);
     }
+
+    console.log("Using client_id:", credentials.clientId);
+    console.log("Redirect URI:", credentials.redirectUri);
 
     const redirectTarget = `${GOOGLE_AUTH_BASE}?${googleParams.toString()}`;
     return res.redirect(302, redirectTarget);


### PR DESCRIPTION
## Summary
- update OAuth credential helper to prefer GOOGLE_REDIRECT_URI when constructing Google OAuth requests
- log the Google OAuth client and redirect URI used during authorization to aid debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5e228580083268ab5a0cbba1ad81d