### PR TITLE
Fix Google OAuth flow for MCP connector

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 const express = require("express");
+const { randomBytes } = require("crypto");
 
-const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_AUTH = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_REDIRECT_URI =
+  (process.env.GOOGLE_REDIRECT_URI && process.env.GOOGLE_REDIRECT_URI.trim()) ||
+  "https://goodseeds-mcp.vercel.app/oauth/callback";
 const DEFAULT_CONNECTOR_REDIRECT = "https://chatgpt.com/connector_platform_oauth_redirect";
-const DEFAULT_CALLBACK = "https://goodseeds-mcp.vercel.app/oauth/callback";
-const DEFAULT_SCOPES = [
+const GOOGLE_SCOPE_LIST = [
   "https://www.googleapis.com/auth/spreadsheets.readonly",
-  "https://www.googleapis.com/auth/drive.readonly",
-  "offline_access"
+  "https://www.googleapis.com/auth/drive.readonly"
 ];
+const GOOGLE_SCOPES = GOOGLE_SCOPE_LIST.join(" ");
+
+const AUTH_CODE_TTL_MS = 5 * 60 * 1000;
  
 const manifest = Object.freeze({
   name: "goodseeds-google-sheets",
@@ -18,7 +23,7 @@ const manifest = Object.freeze({
       type: "oauth",
       oauth_server:
         "https://goodseeds-mcp.vercel.app/.well-known/oauth-authorization-server",
-      scopes: DEFAULT_SCOPES
+      scopes: GOOGLE_SCOPE_LIST
     }
   ],
   terms_of_service_url: "https://goodseeds.ru/connector-terms",
@@ -35,7 +40,7 @@ const oauthMetadata = Object.freeze({
   grant_types_supported: ["authorization_code", "refresh_token"],
   code_challenge_methods_supported: ["S256"],
   token_endpoint_auth_methods_supported: ["none"],
-  scopes_supported: DEFAULT_SCOPES
+  scopes_supported: GOOGLE_SCOPE_LIST
 });
 
 const protectedResourceMetadata = Object.freeze({
@@ -44,72 +49,66 @@ const protectedResourceMetadata = Object.freeze({
     "https://goodseeds-mcp.vercel.app/.well-known/oauth-authorization-server"
   ],
   bearer_methods_supported: ["header"],
-  scopes_supported: DEFAULT_SCOPES
+  scopes_supported: GOOGLE_SCOPE_LIST
 });
 
-function base64UrlEncode(value) {
-  return Buffer.from(value, "utf8")
-    .toString("base64")
-    .replace(/=/g, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_");
+const authorizationCodeStore = new Map();
+
+function pruneExpiredAuthorizationCodes(now = Date.now()) {
+  for (const [code, entry] of authorizationCodeStore.entries()) {
+    if (!entry || entry.expiresAt <= now) {
+      authorizationCodeStore.delete(code);
+    }
+  }
 }
 
-function base64UrlDecode(value) {
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
-  return Buffer.from(normalized + padding, "base64").toString("utf8");
+async function issueAuthorizationCode({ mcpClientId, googleTokens }) {
+  pruneExpiredAuthorizationCodes();
+  const code = randomBytes(32).toString("base64url");
+  const expiresAt = Date.now() + AUTH_CODE_TTL_MS;
+  authorizationCodeStore.set(code, {
+    mcpClientId: mcpClientId || null,
+    googleTokens,
+    issuedAt: Date.now(),
+    expiresAt
+  });
+  return code;
 }
 
-function buildStateEnvelope({ redirectUri, upstreamState }) {
-  const payload = {
-    redirect_uri: redirectUri || DEFAULT_CONNECTOR_REDIRECT,
-    upstream_state: upstreamState || null
-  };
-  return base64UrlEncode(JSON.stringify(payload));
-}
-
-function parseStateEnvelope(value) {
-  if (!value) {
-    return {
-      redirect_uri: DEFAULT_CONNECTOR_REDIRECT,
-      upstream_state: null
-    };
+function consumeAuthorizationCode(code, { mcpClientId } = {}) {
+  if (!code) {
+    return null;
   }
 
-  try {
-    const decoded = base64UrlDecode(value);
-    const parsed = JSON.parse(decoded);
-    return {
-      redirect_uri: parsed.redirect_uri || DEFAULT_CONNECTOR_REDIRECT,
-      upstream_state: parsed.upstream_state || null
-    };
-  } catch (error) {
-    console.error("Failed to parse OAuth state payload", error);
-    return {
-      redirect_uri: DEFAULT_CONNECTOR_REDIRECT,
-      upstream_state: null
-    };
+  pruneExpiredAuthorizationCodes();
+  const entry = authorizationCodeStore.get(code);
+  if (!entry) {
+    return null;
   }
+
+  authorizationCodeStore.delete(code);
+  if (entry.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  if (entry.mcpClientId && mcpClientId && entry.mcpClientId !== mcpClientId) {
+    return null;
+  }
+
+  return entry.googleTokens;
 }
 
 function ensureGoogleCredentials() {
-  const clientId = process.env.GOOGLE_CLIENT_ID;
-  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-
-  if (!clientId) {
-    throw new Error("Missing GOOGLE_CLIENT_ID environment variable");
-  }
-
-  if (!clientSecret) {
-    throw new Error("Missing GOOGLE_CLIENT_SECRET environment variable");
-  }
+  ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"].forEach((key) => {
+    if (!process.env[key] || !process.env[key].trim() || /^['"].*['"]$/.test(process.env[key])) {
+      throw new Error(`Invalid or missing environment variable: ${key}`);
+    }
+  });
 
   return {
-    clientId,
-    clientSecret,
-    redirectUri:
-      process.env.GOOGLE_REDIRECT_URI || process.env.REDIRECT_URI || DEFAULT_CALLBACK
+    clientId: process.env.GOOGLE_CLIENT_ID.trim(),
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET.trim(),
+    redirectUri: GOOGLE_REDIRECT_URI
   };
 }
 
@@ -170,28 +169,27 @@ function createApp() {
 
   app.get("/oauth/authorize", (req, res) => {
     const {
-      client_id: clientId,
-      redirect_uri: connectorRedirect,
+      client_id: mcpClientId,
+      redirect_uri: chatgptRedirectUri,
       response_type: responseType,
-      scope,
-      state,
+      state: chatgptState,
       code_challenge: codeChallenge,
       code_challenge_method: codeChallengeMethod
     } = req.query;
 
-    if (!clientId || clientId !== "goodseeds-chatgpt") {
+    if (!mcpClientId || mcpClientId !== "goodseeds-chatgpt") {
       return res.status(400).send("invalid_client_id");
     }
 
-    if (!connectorRedirect) {
+    if (!chatgptRedirectUri) {
       return res.status(400).send("missing_redirect_uri");
     }
 
-    if (connectorRedirect !== DEFAULT_CONNECTOR_REDIRECT) {
+    if (chatgptRedirectUri !== DEFAULT_CONNECTOR_REDIRECT) {
       return res.status(400).send("unsupported_redirect_uri");
     }
 
-    if (responseType !== "code") {
+    if (responseType && responseType !== "code") {
       return res.status(400).send("unsupported_response_type");
     }
 
@@ -203,57 +201,102 @@ function createApp() {
       return res.status(500).send("server_misconfigured");
     }
 
-    const requestedScopes = (scope || DEFAULT_SCOPES.join(" ")).split(/\s+/).filter(Boolean);
-    const stateEnvelope = buildStateEnvelope({
-      redirectUri: connectorRedirect,
-      upstreamState: state || null
-    });
+    const packed = Buffer.from(
+      JSON.stringify({
+        chatgptRedirectUri,
+        mcpClientId,
+        chatgptState: chatgptState || null
+      })
+    ).toString("base64url");
 
-    const googleParams = new URLSearchParams({
-      client_id: credentials.clientId,
-      redirect_uri: credentials.redirectUri,
-      response_type: "code",
-      access_type: "offline",
-      include_granted_scopes: "true",
-      prompt: "consent",
-      scope: requestedScopes.join(" "),
-      state: stateEnvelope
-    });
-
+    const url = new URL(GOOGLE_AUTH);
+    url.searchParams.set("client_id", credentials.clientId);
+    url.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("scope", GOOGLE_SCOPES);
+    url.searchParams.set("access_type", "offline");
+    url.searchParams.set("prompt", "consent");
+    url.searchParams.set("include_granted_scopes", "true");
+    url.searchParams.set("state", packed);
     if (codeChallenge && codeChallengeMethod) {
-      googleParams.set("code_challenge", codeChallenge);
-      googleParams.set("code_challenge_method", codeChallengeMethod);
+      url.searchParams.set("code_challenge", codeChallenge);
+      url.searchParams.set("code_challenge_method", codeChallengeMethod);
     }
 
-    console.log("Using client_id:", credentials.clientId);
-    console.log("Redirect URI:", credentials.redirectUri);
-
-    const redirectTarget = `${GOOGLE_AUTH_BASE}?${googleParams.toString()}`;
-    return res.redirect(302, redirectTarget);
+    return res.redirect(302, url.toString());
   });
 
-  app.get("/oauth/callback", (req, res) => {
-    const { code, state, error, error_description: errorDescription } = req.query;
+  app.get("/oauth/callback", async (req, res) => {
+    try {
+      const { code, state } = req.query;
+      if (!code || !state) {
+        return res.status(400).send("invalid_request");
+      }
 
-    if (error) {
-      console.error("Google OAuth error", { error, errorDescription });
-      return res.status(400).send(errorDescription || error);
+      let decoded;
+      try {
+        decoded = JSON.parse(Buffer.from(String(state), "base64url").toString("utf8"));
+      } catch (parseError) {
+        console.error("Failed to decode OAuth state", parseError);
+        return res.status(400).send("invalid_state");
+      }
+
+      const { chatgptRedirectUri, mcpClientId, chatgptState } = decoded || {};
+      if (!chatgptRedirectUri) {
+        return res.status(400).send("invalid_state");
+      }
+
+      let credentials;
+      try {
+        credentials = ensureGoogleCredentials();
+      } catch (error) {
+        console.error(error.message);
+        return res.status(500).send("server_misconfigured");
+      }
+
+      const body = new URLSearchParams({
+        code,
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        redirect_uri: GOOGLE_REDIRECT_URI,
+        grant_type: "authorization_code"
+      });
+
+      const tokenRes = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body
+      });
+
+      if (!tokenRes.ok) {
+        const errTxt = await tokenRes.text();
+        return res.status(502).send(`google_token_exchange_failed: ${errTxt}`);
+      }
+
+      const googleTokens = await tokenRes.json();
+      if (!googleTokens.token_type) {
+        googleTokens.token_type = "Bearer";
+      }
+      const asCode = await issueAuthorizationCode({ mcpClientId, googleTokens });
+
+      let out;
+      try {
+        out = new URL(chatgptRedirectUri);
+      } catch (redirectError) {
+        console.error("Invalid ChatGPT redirect URI", redirectError);
+        return res.status(400).send("invalid_redirect_uri");
+      }
+
+      out.searchParams.set("code", asCode);
+      if (chatgptState) {
+        out.searchParams.set("state", chatgptState);
+      }
+
+      return res.redirect(302, out.toString());
+    } catch (e) {
+      console.error(e);
+      return res.status(500).send("server_error");
     }
-
-    if (!code) {
-      return res.status(400).send("missing_code");
-    }
-
-    const { redirect_uri: connectorRedirect, upstream_state: upstreamState } =
-      parseStateEnvelope(state);
-
-    const redirectUrl = new URL(connectorRedirect || DEFAULT_CONNECTOR_REDIRECT);
-    redirectUrl.searchParams.set("code", code);
-    if (upstreamState) {
-      redirectUrl.searchParams.set("state", upstreamState);
-    }
-
-    return res.redirect(302, redirectUrl.toString());
   });
 
   app.post("/oauth/token", async (req, res) => {
@@ -261,69 +304,78 @@ function createApp() {
       grant_type: grantType,
       code,
       refresh_token: refreshToken,
-      code_verifier: codeVerifier
+      client_id: mcpClientId
     } = { ...req.body, ...req.query };
 
-    let credentials;
-    try {
-      credentials = ensureGoogleCredentials();
-    } catch (error) {
-      console.error(error.message);
-      return res.status(500).json({ error: "server_misconfigured" });
+    if (!grantType) {
+      return res.status(400).json({ error: "invalid_request", error_description: "Missing grant_type" });
     }
 
-    const params = new URLSearchParams({
-      client_id: credentials.clientId,
-      client_secret: credentials.clientSecret
-    });
+    if (mcpClientId && mcpClientId !== "goodseeds-chatgpt") {
+      return res.status(400).json({ error: "invalid_client" });
+    }
 
     if (grantType === "authorization_code") {
       if (!code) {
         return res.status(400).json({ error: "invalid_request", error_description: "Missing code" });
       }
 
-      params.set("grant_type", "authorization_code");
-      params.set("code", code);
-      params.set("redirect_uri", credentials.redirectUri);
-      if (codeVerifier) {
-        params.set("code_verifier", codeVerifier);
+      const tokens = consumeAuthorizationCode(code, { mcpClientId: "goodseeds-chatgpt" });
+      if (!tokens) {
+        return res.status(400).json({ error: "invalid_grant" });
       }
-    } else if (grantType === "refresh_token") {
+
+      return res.status(200).json(tokens);
+    }
+
+    if (grantType === "refresh_token") {
       if (!refreshToken) {
         return res
           .status(400)
           .json({ error: "invalid_request", error_description: "Missing refresh_token" });
       }
 
-      params.set("grant_type", "refresh_token");
-      params.set("refresh_token", refreshToken);
-    } else {
-      return res.status(400).json({ error: "unsupported_grant_type" });
-    }
+      let credentials;
+      try {
+        credentials = ensureGoogleCredentials();
+      } catch (error) {
+        console.error(error.message);
+        return res.status(500).json({ error: "server_misconfigured" });
+      }
 
-    try {
-      const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: params.toString()
+      const params = new URLSearchParams({
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        refresh_token: refreshToken,
+        grant_type: "refresh_token"
       });
 
-      const payload = await response.json();
+      try {
+        const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: params.toString()
+        });
 
-      if (!response.ok) {
-        console.error("Google token endpoint returned an error", payload);
-        return res.status(response.status).json(payload);
+        const payload = await response.json();
+
+        if (!response.ok) {
+          console.error("Google token endpoint returned an error", payload);
+          return res.status(response.status).json(payload);
+        }
+
+        if (!payload.token_type) {
+          payload.token_type = "Bearer";
+        }
+
+        return res.status(200).json(payload);
+      } catch (error) {
+        console.error("Token refresh failed", error);
+        return res.status(500).json({ error: "token_exchange_failed" });
       }
-
-      if (!payload.token_type) {
-        payload.token_type = "Bearer";
-      }
-
-      return res.status(200).json(payload);
-    } catch (error) {
-      console.error("Token exchange failed", error);
-      return res.status(500).json({ error: "token_exchange_failed" });
     }
+
+    return res.status(400).json({ error: "unsupported_grant_type" });
   });
 
   app.use((req, res) => {
@@ -343,13 +395,6 @@ function createApp() {
 }
 
 const app = createApp();
-
-if (require.main === module) {
-  const port = process.env.PORT || 3000;
-  app.listen(port, () => {
-    console.log(`Goodseeds MCP OAuth connector listening on port ${port}`);
-  });
-}
 
 module.exports = app;
 module.exports.handler = (req, res) => app(req, res);


### PR DESCRIPTION
## Summary
- ensure the authorize handler uses the Google OAuth client credentials, packs ChatGPT parameters in state, and redirects with the connector callback
- exchange Google authorization codes on the callback, issue short-lived connector codes, and send ChatGPT back to its redirect URI
- serve stored Google tokens from `/oauth/token`, proxy refreshes, and validate OAuth environment variables at runtime

## Testing
- node -e "require('./index.js')"


------
https://chatgpt.com/codex/tasks/task_b_68e5f744dfd88326864e87ad77905678