### PR TITLE
Add stateless fallback for invalid OAuth state

### DIFF
--- a/__tests__/oauth.test.js
+++ b/__tests__/oauth.test.js
@@ -1,0 +1,123 @@
+const { describe, it, before, after, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+const app = require("../index.js");
+
+describe("OAuth state handling", () => {
+  let server;
+  let baseUrl;
+  let originalFetch;
+  let originalClientId;
+  let originalClientSecret;
+
+  before(async () => {
+    server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    originalClientId = process.env.GOOGLE_CLIENT_ID;
+    originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+    process.env.GOOGLE_CLIENT_ID = "test-client-id";
+    process.env.GOOGLE_CLIENT_SECRET = "test-client-secret";
+  });
+
+  afterEach(() => {
+    if (originalClientId === undefined) {
+      delete process.env.GOOGLE_CLIENT_ID;
+    } else {
+      process.env.GOOGLE_CLIENT_ID = originalClientId;
+    }
+
+    if (originalClientSecret === undefined) {
+      delete process.env.GOOGLE_CLIENT_SECRET;
+    } else {
+      process.env.GOOGLE_CLIENT_SECRET = originalClientSecret;
+    }
+
+    global.fetch = originalFetch;
+  });
+
+  it("should redirect to Google with proper redirect_uri", async () => {
+    const authorizeUrl = new URL(`${baseUrl}/oauth/authorize`);
+    authorizeUrl.searchParams.set("client_id", "goodseeds-chatgpt");
+    authorizeUrl.searchParams.set(
+      "redirect_uri",
+      "https://chatgpt.com/connector_platform_oauth_redirect"
+    );
+    authorizeUrl.searchParams.set("response_type", "code");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+
+    assert.equal(response.status, 302);
+    const location = response.headers.get("location");
+    assert.ok(location.includes("accounts.google.com"));
+
+    const redirectUrl = new URL(location);
+    assert.equal(
+      redirectUrl.searchParams.get("redirect_uri"),
+      "https://goodseeds-mcp.vercel.app/oauth/callback"
+    );
+  });
+
+  it("should not crash when callback is called with broken state", async () => {
+    const nodeFetch = originalFetch;
+    global.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (typeof url === "string" && url.startsWith("https://oauth2.googleapis.com/")) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: "test-access-token",
+            refresh_token: "test-refresh-token",
+            expires_in: 3600,
+            token_type: "Bearer"
+          }),
+          text: async () => "ok"
+        };
+      }
+
+      return nodeFetch(input, init);
+    };
+
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      warnings.push(args.map(String).join(" "));
+      if (typeof originalWarn === "function") {
+        originalWarn(...args);
+      }
+    };
+
+    try {
+      const callbackUrl = new URL(`${baseUrl}/oauth/callback`);
+      callbackUrl.searchParams.set("code", "test-code");
+      callbackUrl.searchParams.set("state", "!!!invalid-state!!!");
+
+      const response = await fetch(callbackUrl, { redirect: "manual" });
+
+      assert.equal(response.status, 302);
+      const location = response.headers.get("location");
+      assert.ok(location.includes("chatgpt.com"));
+
+      const redirectUrl = new URL(location);
+      assert.ok(redirectUrl.searchParams.get("code"));
+      assert.equal(redirectUrl.searchParams.get("state"), null);
+      assert.ok(
+        warnings.some((message) => message.includes("⚠️ Skipping invalid state (stateless fallback)"))
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function createApp() {
         return res.status(400).send("invalid_request");
       }
 
-      let decoded;
+      let decoded = {};
       let chatgptRedirectUri = DEFAULT_CONNECTOR_REDIRECT;
       let mcpClientId = null;
       let chatgptState = null;
@@ -292,13 +292,14 @@ function createApp() {
         try {
           decoded = JSON.parse(Buffer.from(String(state), "base64url").toString("utf8"));
         } catch (parseError) {
-          console.warn("Invalid OAuth state, continuing stateless mode", parseError);
+          console.warn("⚠️ Skipping invalid state (stateless fallback)", parseError);
+          decoded = {};
         }
       } else {
-        console.warn("Missing OAuth state, continuing stateless mode");
+        console.warn("⚠️ Skipping invalid state (stateless fallback) - missing state");
       }
 
-      if (decoded && typeof decoded === "object") {
+      if (decoded && typeof decoded === "object" && !Array.isArray(decoded)) {
         if (typeof decoded.chatgptRedirectUri === "string" && decoded.chatgptRedirectUri.trim()) {
           chatgptRedirectUri = decoded.chatgptRedirectUri;
         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "commonjs",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.19.2"


### PR DESCRIPTION
## Summary
- harden the OAuth callback handler to fall back gracefully when the state payload is missing or malformed and log a warning
- add automated tests covering the authorize redirect flow and stateless fallback handling
- expose an npm test script so CI can exercise the new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e65dca90ac832698b3d6d89afd89ed